### PR TITLE
Updated frontend for create posts

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -7,6 +7,7 @@ import { validateLogin } from './common/apiService';
 import Home from './components/Home/Home';
 import EditProfile from './components/EditProfile/EditProfile';
 import { AuthProvider, useAuth } from './common/auth';
+import CreatePost from './components/CreatePost';
 
 function RequireAuth({ children }: { children: JSX.Element }) {
   let auth = useAuth();
@@ -66,6 +67,7 @@ export default function App() {
           <Route path='/login' element={<RequireNoAuth><Login /></RequireNoAuth>} />
           <Route path='/register' element={<RequireNoAuth><Register /></RequireNoAuth>} />
           <Route path='/edit-profile' element={<RequireAuth><EditProfile /></RequireAuth>} />
+          <Route path='/create-post' element={<RequireAuth><CreatePost /></RequireAuth>} />
         </Routes>
       </Router>
     </AuthProvider>

--- a/client/src/CreatePost.tsx
+++ b/client/src/CreatePost.tsx
@@ -1,0 +1,181 @@
+import { theme } from '../common/theme';
+import { ThemeProvider } from '@mui/material/styles';
+import { CssBaseline, Typography, GlobalStyles, Container, Box, Button, TextField, MenuItem } from '@mui/material';
+import NavBar from './NavBar';
+import React, { useEffect } from 'react';
+import Toast from './common/Toast';
+import { TextValidator, ValidatorForm } from 'react-material-ui-form-validator';
+import { createPost, getCompanies } from '../common/apiService';
+import { createPostFormType, companyType } from '../types';
+import { isUrlText } from './common/customValidationRules';
+
+export default function CreatePost() {
+
+    const initialFormValues = () => {
+        return {
+            targetCompanyId: 1,
+            targetPosition: "",
+            message: "",
+            resume: "",
+            jobLink: ""
+        };
+    };
+
+    const [formValues, setFormValues] = React.useState<createPostFormType>(initialFormValues());
+    const [companies, setCompanies] = React.useState<companyType[]>([]);
+    const [error, setError] = React.useState(null);
+    const [showToast, setShowToast] = React.useState(false);
+    const [toastSeverity, setToastSeverity] = React.useState("success");
+    const [toastMessage, setToastMessage] = React.useState("");
+
+    const handleSubmit = (event: React.FormEvent<Element>) => {
+        event.preventDefault();
+        createPost(formValues)
+            .then((res: any) => {
+                displayToast("success", "Post created");
+                setFormValues(initialFormValues());
+            })
+            .catch((error: any) => {
+                displayToast("error", error.message);
+            });
+    };
+
+    const displayToast = (severity: string, message: string) => {
+        setShowToast(true);
+        setToastSeverity(severity);
+        setToastMessage(message);
+    };
+
+    useEffect(() => {
+        ValidatorForm.addValidationRule('isTruthy', (value: any) => value);
+        ValidatorForm.addValidationRule('isUrl', value => {
+            return isUrlText(value)
+          })
+        getCompanies()
+            .then((res: React.SetStateAction<companyType[]>) => {
+                setCompanies(res);
+            })
+            .catch((error: React.SetStateAction<null>) => {
+                setError(error);
+            });
+    }, []);
+
+    const handleChange =
+        (prop: keyof createPostFormType) => (event: React.ChangeEvent<HTMLInputElement>) => {
+            setFormValues({ ...formValues, [prop]: event.target.value });
+        };
+
+    return (
+        <ThemeProvider theme={theme}>
+            <GlobalStyles styles={{ ul: { margin: 0, padding: 0, listStyle: 'none' } }} />
+            <CssBaseline />
+            < NavBar />
+            {/* Hero unit */}
+            <Container disableGutters maxWidth="md" component="main" sx={{ pt: 8, pb: 4 }}>
+                <Typography variant="h5" align="center" color="text.secondary" component="p">
+                    Create Post
+                </Typography>
+            </Container>
+            <Container
+                maxWidth="xs"
+                component="footer"
+                sx={{
+                    borderTop: (theme) => `1px solid ${theme.palette.divider}`,
+                    mt: 1,
+                    py: [3, 6],
+                    alignItems: 'center',
+                }}
+            >
+                <Box
+                    sx={{ mt: 1, width: '100%' }}
+                >
+                    <ValidatorForm
+                        onSubmit={handleSubmit}
+                        onError={(errors: any) => console.log(errors)}
+                    >
+                        <TextValidator
+                            margin="normal"
+                            validators={["required"]}
+                            errorMessages={["this field is required"]}
+                            fullWidth
+                            id="targetPosition"
+                            value={formValues.targetPosition}
+                            label="Target Position"
+                            name="targetPosition"
+                            onChange={handleChange("targetPosition")}
+                        />
+                        <TextValidator
+                            margin="normal"
+                            validators={["required", "maxStringLength: 300"]}
+                            errorMessages={["this field is required", "Message should be maximum 300 chars long"]}
+                            fullWidth
+                            id="message"
+                            label="Message"
+                            name="message"
+                            value={formValues.message}
+                            multiline
+                            rows={5}
+                            onChange={handleChange("message")}
+                        />
+                        <TextValidator
+                            margin="normal"
+                            validators={["required", "isUrl"]}
+                            errorMessages={["this field is required", "Resume link must be a url and begins with http/https"]}
+                            fullWidth
+                            id="resume"
+                            value={formValues.resume}
+                            label="Resume Link"
+                            name="resume"
+                            autoComplete="resume"
+                            onChange={handleChange("resume")}
+                        />
+                        <TextValidator
+                            margin="normal"
+                            validators={["required", "isUrl"]}
+                            errorMessages={["this field is required", "Job link must be a url and begins with http/https"]}
+                            fullWidth
+                            id="jobLink"
+                            value={formValues.jobLink}
+                            label="Job Link"
+                            name="jobLink"
+                            onChange={handleChange("jobLink")}
+                        />
+                        <TextField
+                            margin="normal"
+                            id="targetCompanyId"
+                            select
+                            fullWidth
+                            label="Target Company"
+                            value={formValues.targetCompanyId}
+                            onChange={handleChange("targetCompanyId")}
+                        >
+                            {companies &&
+                                companies.map((company) => (
+                                    <MenuItem
+                                        value={company.companyId}
+                                        key={company.companyId}
+                                    >
+                                        {company.name}
+                                    </MenuItem>
+                                ))}
+                        </TextField>
+                        <Button
+                            type='submit'
+                            fullWidth
+                            variant='contained'
+                            sx={{ mt: 3, mb: 2 }}
+                        >
+                            Post
+                        </Button>
+                    </ValidatorForm>
+                </Box>
+                <Toast
+                    open={showToast}
+                    severity={toastSeverity}
+                    message={toastMessage}
+                    setOpen={setShowToast}
+                />
+            </Container>
+        </ThemeProvider>
+    );
+}

--- a/client/src/common/apiService.tsx
+++ b/client/src/common/apiService.tsx
@@ -1,5 +1,5 @@
 import axios from 'axios'
-import { registerFormType, loginType, profileFormType, emailFormType, passwordFormType } from '../types';
+import { registerFormType, loginType, profileFormType, emailFormType, passwordFormType, createPostFormType } from '../types';
 
 const api = axios.create({
   withCredentials: true,
@@ -81,4 +81,17 @@ export function deletePostById(postId: number) {
   .then((res) => {
     return res.data
   });
+};
+
+export function getCompanies() {
+  return api.get('companies', {}).then((res) => {
+    return res.data
+  });
+};
+
+export function createPost(createPostFormValues: createPostFormType) {
+  return api.post('posts/newpost', createPostFormValues, {headers: {"Content-Type": "application/x-www-form-urlencoded"}})
+    .then((res) => {
+      return res.data
+    })
 };

--- a/client/src/components/common/customValidationRules.tsx
+++ b/client/src/components/common/customValidationRules.tsx
@@ -1,0 +1,10 @@
+export function isUrlText(value: string) {
+    const valueToTest = value || ''
+    let urlRegexp = new RegExp(
+      '^http(s?)://[0-9a-zA-Z]([-.w]*[0-9a-zA-Z])*?[a-z0-9][-a-z0-9]{0,61}[a-z0-9]\\.[a-z]{2,6}(/[\\w\\s-\\w@\\+\\.~#\\?&/=%]*)?$'
+    )
+    if (valueToTest && !urlRegexp.test(valueToTest)) {
+      return false
+    }
+    return true
+  }

--- a/client/src/types.tsx
+++ b/client/src/types.tsx
@@ -78,3 +78,11 @@ export type userType = {
     password: string,
     verified: boolean
 }
+
+export type createPostFormType = {
+    targetCompanyId: number; 
+    targetPosition: string; 
+    message: string; 
+    resume: string; 
+    jobLink: string;
+}


### PR DESCRIPTION
## Acceptance criteria
- [x] This page should be accessible at '\create-post' with a green POST button in the navbar.
- [x] Input fields for target position name, message for the referrer, job link, resume link, select target company from the dropdown (taken from Company table). 
- [x] URL validation for entering only valid urls in resume link and job link input fields
- [x] Show required and invalid url errors in input fields
- [x] "POST" button below the form to create the post.
- [x] Send form data to backend at `\api\posts\newpost`
- [x] Clear form data if success, and show success toast or show error toast.
- [x] This page should be accessible only for logged in users.